### PR TITLE
Fix: [Modal Results] Remove 'away' from vicinity tidbit

### DIFF
--- a/src/main/webapp/index-script.js
+++ b/src/main/webapp/index-script.js
@@ -273,7 +273,7 @@ function generateResult(place) {
     place.name,
     place.international_phone_number,
     "<a href=\"" + place.website + "\">Site</a>",
-    place.vicinity + " away"
+    place.vicinity
   ];
 
   tidbits = tidbits.filter(function (element) {


### PR DESCRIPTION
Fixed display error of adding "away" after a business location.