### PR TITLE
Fix: [Results Modal] <ul> Disambiguation

### DIFF
--- a/src/main/webapp/index-script.js
+++ b/src/main/webapp/index-script.js
@@ -244,7 +244,7 @@ function closeModal(modal) {
  * Calls on closing of modal, wipes all results from inside of it.
  */
 function cleanModal(modal) {
-  const listContainer = document.getElementById('results-list');
+  const listContainer = document.getElementById('results-list-container');
   listContainer.innerHTML = ''; // Clean wrapper of all DOM elements
 }
 
@@ -254,8 +254,9 @@ function cleanModal(modal) {
  */
 function populateResults(places) {
   console.log('Populating results modal...');
-  const listContainer = document.getElementById('results-list');
-  const entireList = document.createElement('ul');
+  const listContainer = document.getElementById('results-list-container');
+  const entireList = document.createElement('ul'); // Results ul
+  entireList.id += "results-list";
   places.forEach(place => {
     entireList.appendChild(generateResult(place));
   });
@@ -281,7 +282,7 @@ function generateResult(place) {
   suggestedIcon.src = place.icon;
   imagePreview.appendChild(suggestedIcon);
   resultGrid.appendChild(imagePreview);
-  const infoText = document.createElement('ul');
+  const infoText = document.createElement('ul'); // Tidbits ul
   
   // Relevant information to be displayed
   var tidbits = [

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -46,7 +46,7 @@
           <button data-modal-close-button class="exit-button">&times;</button>
         </div>
         <div class="modal-body">
-          <div id="results-list"></div>
+          <div id="results-list-container"></div>
         </div>
       </div>
       <div id="overlay"></div>

--- a/src/main/webapp/modal-overlay.css
+++ b/src/main/webapp/modal-overlay.css
@@ -61,6 +61,7 @@
   -webkit-overflow-scrolling: touch;
 }
 
+/* Custom max-height to not overrun modal body */
 .modal-body ul#results-list {
   max-height: 74vh;
 }

--- a/src/main/webapp/modal-overlay.css
+++ b/src/main/webapp/modal-overlay.css
@@ -61,8 +61,8 @@
   -webkit-overflow-scrolling: touch;
 }
 
-.modal-body div#results-list {
-  max-height: inherit;
+.modal-body ul#results-list {
+  max-height: 74vh;
 }
 
 /* The gray overlay of the map background */


### PR DESCRIPTION
### Modal Punch List #36.2
Changes html element naming in modal class to allow for a different styling between the two different nested ```<ul>``` elements. Primarily, prevents the results list from running over the modal body by adding a `max-height: 74vh;` field.