### PR TITLE
[Fixes + Features]: Sort reviews (& Friends)

### DIFF
--- a/src/main/java/com/google/sps/data/Comment.java
+++ b/src/main/java/com/google/sps/data/Comment.java
@@ -66,8 +66,8 @@ public class Comment {
     this.messageContent = message;
     this.timestamp = timestamp;
     this.rating = rating;
-    this.positive = 0L;
-    this.negative = 0L;
+    this.positive = positive;
+    this.negative = negative;
   }
 
   /** Return the id of the comment */

--- a/src/main/java/com/google/sps/data/Comment.java
+++ b/src/main/java/com/google/sps/data/Comment.java
@@ -20,6 +20,7 @@ public class Comment {
   private String username;
   private String currUserVote;
   private double rating;
+  private double weightedRating;
 
   /**
    * Order Comparator

--- a/src/main/java/com/google/sps/data/Comment.java
+++ b/src/main/java/com/google/sps/data/Comment.java
@@ -45,8 +45,19 @@ public class Comment {
   };
 
   /**
+   * Order Comparator by weightedRating
+   * This comparator orders the comments by their weightedRating.
+   */
+  public static final Comparator<Comment> ORDER_BY_WEIGHTED_RATING = new Comparator<Comment>() {
+    @Override
+    public int compare(Comment a, Comment b) {
+      return Double.compare(b.getWeightedRating(), a.getWeightedRating());
+    }
+  };
+
+  /**
    * Order Comparator by MetaScore
-   * This comparator orders the comments by their score
+   * This comparator orders the comments by their net votes.
    */
   public static final Comparator<Comment> ORDER_BY_SCORE = new Comparator<Comment>() {
     @Override
@@ -130,6 +141,20 @@ public class Comment {
     return this.timestamp;
   }
 
+  /** 
+   * weightedRating Setter method
+   * Updates private variable
+   */
+  public void setWeightedRating(double rating) {
+    this.weightedRating = rating;
+  }
+
+  /** 
+   * Retrieves private variable weightedRating
+   */
+  public double getWeightedRating() {
+    return this.weightedRating;
+  }
   /** 
    * Update Comment
    * This function is used when a author want's to submit a new comment for a location.

--- a/src/main/java/com/google/sps/data/PlaceReviews.java
+++ b/src/main/java/com/google/sps/data/PlaceReviews.java
@@ -100,7 +100,14 @@ public class PlaceReviews {
     } else if(sortType.equals("recent")) {
       Collections.sort(this.reviews, Comment.ORDER_BY_DATE);
     } else {
-      Collections.sort(this.reviews, Comment.ORDER_BY_SCORE);
+      Collections.sort(this.reviews, Comment.ORDER_BY_DATE);
+      List<Comment> weightedSorting = new ArrayList<Comment>(this.reviews);
+      for(int i = 0; i < this.reviews.size(); i++) {
+        weightedSorting.get(i).setWeightedRating(this.reviews.get(i).getRating() * (this.reviews.size() - i));
+      }
+      Collections.sort(weightedSorting, Comment.ORDER_BY_WEIGHTED_RATING);
+      this.reviews.clear();
+      this.reviews.addAll(weightedSorting);
     }
   }
 

--- a/src/main/java/com/google/sps/data/PlaceReviews.java
+++ b/src/main/java/com/google/sps/data/PlaceReviews.java
@@ -95,9 +95,9 @@ public class PlaceReviews {
    * they gave a location weighted by their recency.
    */
   public void sortReviews(String sortType) {
-    if (sortType == "highest-rated") {
+    if (sortType.equals("highest-rated")) {
       Collections.sort(this.reviews, Comment.ORDER_BY_SCORE);
-    } else if(sortType == "recent") {
+    } else if(sortType.equals("recent")) {
       Collections.sort(this.reviews, Comment.ORDER_BY_DATE);
     } else {
       Collections.sort(this.reviews, Comment.ORDER_BY_SCORE);

--- a/src/main/java/com/google/sps/data/PlaceReviews.java
+++ b/src/main/java/com/google/sps/data/PlaceReviews.java
@@ -90,13 +90,17 @@ public class PlaceReviews {
 
   /**
    * Public sorting method
-   * Sorts the internal Comment list to the type requested
+   * Sorts the internal Comment list by their voter rating, recency,
+   * or "relevancy" where "relevancy" is defined as the scores
+   * they gave a location weighted by their recency.
    */
   public void sortReviews(String sortType) {
-    if (sortType == "relevant") {
+    if (sortType == "highest-rated") {
       Collections.sort(this.reviews, Comment.ORDER_BY_SCORE);
-    } else {
+    } else if(sortType == "recent") {
       Collections.sort(this.reviews, Comment.ORDER_BY_DATE);
+    } else {
+      Collections.sort(this.reviews, Comment.ORDER_BY_SCORE);
     }
   }
 

--- a/src/main/java/com/google/sps/servlets/ReviewServlet.java
+++ b/src/main/java/com/google/sps/servlets/ReviewServlet.java
@@ -61,15 +61,9 @@ public class ReviewServlet extends HttpServlet {
       String author = (String) review.getProperty("author");
       double rate = (review.getProperty("rate") == null) ? 0 : ((Long) review.getProperty("rate")).doubleValue();
       rating += rate;
-      Long positive = 0L;
-      Long negative = 0L;
-      
-      if ((String) review.getProperty("positive") != null){
-        positive = Long.parseLong((String) review.getProperty("positive"));
-      }
-      if ((String) review.getProperty("negative") != null){
-        negative = Long.parseLong((String) review.getProperty("negative"));
-      }
+      Long positive = Long.parseLong((String) review.getProperty("positive"));
+      Long negative = Long.parseLong((String) review.getProperty("negative"));
+     
       Comment com = new Comment(author, message, timestamp, positive, negative, rate);
       com.setId(id);
       currentPlace.addReview(com);

--- a/src/main/webapp/index-script.js
+++ b/src/main/webapp/index-script.js
@@ -31,7 +31,7 @@ function loadMainButtons() {
   });
   
   const modalBackArrow = document.getElementById("modal-backarrow");
-  const commentSortRelevant = document.getElementById("comment-sort-relevant");
+  const commentSortHighestRated = document.getElementById("comment-sort-highest-rated");
   const commentSortRecent = document.getElementById("comment-sort-recent");
 
   // Hide reviews page and display results page.
@@ -39,15 +39,15 @@ function loadMainButtons() {
     returnToResultsScreen();
   });
 
-  commentSortRelevant.addEventListener("click", () => {
-    commentSortRelevant.classList.add("active");
+  commentSortHighestRated.addEventListener("click", () => {
+    commentSortHighestRated.classList.add("active");
     commentSortRecent.classList.remove("active");
-    resortReviews(prev_ID, 'relevant');
+    resortReviews(prev_ID, 'highest-rated');
   });
   
-  commentSortRecent.addEventListener("click", () => {
+  commentSortRecent.addEvzdsfsdfsdfsdfstener("click", () => {
     commentSortRecent.classList.add("active");
-    commentSortRelevant.classList.remove("active");
+    commentSortHighestRated.classList.remove("active");
     resortReviews(prev_ID, 'recent');
   });
 }

--- a/src/main/webapp/index-script.js
+++ b/src/main/webapp/index-script.js
@@ -48,21 +48,29 @@ function loadMainButtons() {
   commentSortRecent.addEventListener("click", () => {
     commentSortRecent.classList.add("active");
     commentSortHighestRated.classList.remove("active");
-    resortReviews(prev_ID, 'recent');fvotin
+    resortReviews(prev_ID, 'recent');
   });
 }
 
 /** Clears top layers of modal and displays results page. */
 function returnToResultsScreen() {
+  returnToReviewScreen();
   hideButton(document.getElementById("modal-backarrow"));
   hideButton(document.getElementById("comment-sort-highest-rated"));
   hideButton(document.getElementById("comment-sort-recent"));
   hideButton(document.getElementById('reviews-body'));
-  hideButton(document.getElementById('rev-form-body'));
-  hideButton(document.getElementById("submit-new-review"));
 
   document.getElementById('results-body').style.display = "block"; // Display results page.
   document.getElementById('reviews-list-container').innerHTML = ''; // Clean reviews wrapper of all DOM elements;
+}
+
+/** Wipes review form from page. */
+function returnToReviewScreen() {
+  document.getElementById('fname').value = '';
+  document.getElementById('lname').value = '';
+  document.getElementById('comment').value = '';
+  hideButton(document.getElementById('rev-form-body'));
+  document.querySelector('#submit-button').innerHTML = '';
 }
 
 /* Adds mouse listeners to searchBar-related html items. */
@@ -587,10 +595,15 @@ function triggerNewReviewForm(place_id) {
   document.getElementById("place_id").value = place_id;
   document.getElementById("reviews-body").style.display = "none"; // Hide reviews page.
   document.getElementById("rev-form-body").style.display = "block";
-  document.getElementById("submit-new-review")
-    .addEventListener("click", () => {
-      postNewReview(place_id);
-    });
+  hideButton(document.getElementById('comment-sort-highest-rated'));
+  hideButton(document.getElementById('comment-sort-recent'));
+  const newReviewSubmit = document.createElement('button');
+  newReviewSubmit.innerHTML = 'Submit';
+  newReviewSubmit.id = 'submit-new-review';
+  newReviewSubmit.addEventListener("click", () => {
+    postNewReview(place_id);
+  });
+  document.getElementById('submit-button').appendChild(newReviewSubmit);
 }
 
 /** Function posts new review to datastore and updates modal reviews page with new review. */
@@ -601,12 +614,10 @@ function postNewReview(place_id) {
   const rate = getRating();
   const request = '/review?firstName=' + first + '&rate=' + rate +
     '&lastName=' + last + '&comment=' + comment + '&place_id=' + place_id;
-  document.getElementById('fname').value = '';
-  document.getElementById('lname').value = '';
-  document.getElementById('comment').value = '';
   fetch(request, {method:"POST"}).then(() => {
+    returnToReviewScreen();
     returnToResultsScreen();
-    showReviews(place_id, false);
+    //showReviews(place_id, false);
   });
 }
 

--- a/src/main/webapp/index-script.js
+++ b/src/main/webapp/index-script.js
@@ -45,20 +45,22 @@ function loadMainButtons() {
     resortReviews(prev_ID, 'highest-rated');
   });
   
-  commentSortRecent.addEvzdsfsdfsdfsdfstener("click", () => {
+  commentSortRecent.addEventListener("click", () => {
     commentSortRecent.classList.add("active");
     commentSortHighestRated.classList.remove("active");
-    resortReviews(prev_ID, 'recent');
+    resortReviews(prev_ID, 'recent');fvotin
   });
 }
 
 /** Clears top layers of modal and displays results page. */
 function returnToResultsScreen() {
   hideButton(document.getElementById("modal-backarrow"));
-  hideButton(document.getElementById("comment-sort-relevant"));
+  hideButton(document.getElementById("comment-sort-highest-rated"));
   hideButton(document.getElementById("comment-sort-recent"));
   hideButton(document.getElementById('reviews-body'));
   hideButton(document.getElementById('rev-form-body'));
+  hideButton(document.getElementById("submit-new-review"));
+
   document.getElementById('results-body').style.display = "block"; // Display results page.
   document.getElementById('reviews-list-container').innerHTML = ''; // Clean reviews wrapper of all DOM elements;
 }
@@ -152,7 +154,7 @@ function closeModal(modal) {
   });
   hideButton(document.getElementById("modal-backarrow"));
   hideButton(document.getElementById("comment-sort-recent"));
-  hideButton(document.getElementById("comment-sort-relevant"));
+  hideButton(document.getElementById("comment-sort-highest-rated"));
 }
 
 /** Multi-purpose button hiding function */
@@ -386,7 +388,7 @@ function triggerModal(modal) {
   modal.classList.add('active');
   document.getElementById('results-body').style.display = "block";
   hideButton(document.getElementById("modal-backarrow"));
-  hideButton(document.getElementById("comment-sort-relevant"));
+  hideButton(document.getElementById("comment-sort-highest-rated"));
   hideButton(document.getElementById("comment-sort-recent"));
 }
 
@@ -517,7 +519,7 @@ function enableBackArrow() {
 
 /** Displays sort options button. */
 function enableSortOptions() {
-  const commentSortRelevant = document.getElementById("comment-sort-relevant");
+  const commentSortRelevant = document.getElementById("comment-sort-highest-rated");
   commentSortRelevant.style.display = "block";
   const commentSortRecent = document.getElementById("comment-sort-recent");
   commentSortRecent.style.display = "block";
@@ -599,6 +601,9 @@ function postNewReview(place_id) {
   const rate = getRating();
   const request = '/review?firstName=' + first + '&rate=' + rate +
     '&lastName=' + last + '&comment=' + comment + '&place_id=' + place_id;
+  document.getElementById('fname').value = '';
+  document.getElementById('lname').value = '';
+  document.getElementById('comment').value = '';
   fetch(request, {method:"POST"}).then(() => {
     returnToResultsScreen();
     showReviews(place_id, false);
@@ -610,8 +615,10 @@ function getRating() {
   var radios = document.getElementsByName('rate');
   for (var i = 0, length = radios.length; i < length; i++) {
     if (radios[i].checked) {
+      radios[i].style.color = "#ccc;"
       return radios[i].value;
     }
+    radios[i].style.color = "#ccc;"
   }
   return 0;
 }

--- a/src/main/webapp/index-script.js
+++ b/src/main/webapp/index-script.js
@@ -33,6 +33,7 @@ function loadMainButtons() {
   const modalBackArrow = document.getElementById("modal-backarrow");
   const commentSortHighestRated = document.getElementById("comment-sort-highest-rated");
   const commentSortRecent = document.getElementById("comment-sort-recent");
+  const commentSortRelevant = document.getElementById("comment-sort-relevant");
 
   // Hide reviews page and display results page.
   modalBackArrow.addEventListener("click", () => {
@@ -42,14 +43,23 @@ function loadMainButtons() {
   commentSortHighestRated.addEventListener("click", () => {
     commentSortHighestRated.classList.add("active");
     commentSortRecent.classList.remove("active");
+    commentSortRelevant.classList.remove("active");
     resortReviews(prev_ID, 'highest-rated');
   });
   
   commentSortRecent.addEventListener("click", () => {
     commentSortRecent.classList.add("active");
     commentSortHighestRated.classList.remove("active");
+    commentSortRelevant.classList.remove("active");
     resortReviews(prev_ID, 'recent');
   });
+
+  commentSortRelevant.addEventListener("click", () => {
+    commentSortRelevant.classList.add("active");
+    commentSortHighestRated.classList.remove("active");
+    commentSortRecent.classList.remove("active");
+    resortReviews(prev_ID, 'relevant');
+  })
 }
 
 /** Clears top layers of modal and displays results page. */
@@ -58,6 +68,7 @@ function returnToResultsScreen() {
   hideButton(document.getElementById("modal-backarrow"));
   hideButton(document.getElementById("comment-sort-highest-rated"));
   hideButton(document.getElementById("comment-sort-recent"));
+  hideButton(document.getElementById("comment-sort-relevant"));
   hideButton(document.getElementById('reviews-body'));
 
   document.getElementById('results-body').style.display = "block"; // Display results page.
@@ -163,6 +174,7 @@ function closeModal(modal) {
   hideButton(document.getElementById("modal-backarrow"));
   hideButton(document.getElementById("comment-sort-recent"));
   hideButton(document.getElementById("comment-sort-highest-rated"));
+  hideButton(document.getElementById("comment-sort-relevant"));
 }
 
 /** Multi-purpose button hiding function */
@@ -398,6 +410,7 @@ function triggerModal(modal) {
   hideButton(document.getElementById("modal-backarrow"));
   hideButton(document.getElementById("comment-sort-highest-rated"));
   hideButton(document.getElementById("comment-sort-recent"));
+  hideButton(document.getElementById("comment-sort-relevant"));
 }
 
 /* This function takes in an array of JS places and creates an unordered
@@ -527,10 +540,12 @@ function enableBackArrow() {
 
 /** Displays sort options button. */
 function enableSortOptions() {
-  const commentSortRelevant = document.getElementById("comment-sort-highest-rated");
-  commentSortRelevant.style.display = "block";
+  const commentSortHighestRated = document.getElementById("comment-sort-highest-rated");
+  commentSortHighestRated.style.display = "block";
   const commentSortRecent = document.getElementById("comment-sort-recent");
   commentSortRecent.style.display = "block";
+  const commentSortRelevant = document.getElementById("comment-sort-relevant");
+  commentSortRelevant.style.display = "block";
 }
 
 /** Displays review-body and hides results-body. */
@@ -597,6 +612,7 @@ function triggerNewReviewForm(place_id) {
   document.getElementById("rev-form-body").style.display = "block";
   hideButton(document.getElementById('comment-sort-highest-rated'));
   hideButton(document.getElementById('comment-sort-recent'));
+  hideButton(document.getElementById('comment-sort-relevant'));
   const newReviewSubmit = document.createElement('button');
   newReviewSubmit.innerHTML = 'Submit';
   newReviewSubmit.id = 'submit-new-review';

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -61,7 +61,7 @@
           <button id="modal-backarrow"></button>
           <div class="button-group" id="comment-sorting" value="">
             <button id="comment-sort-recent">Recently Posted</button>
-            <button id="comment-sort-relevant">Highest Rated</button>
+            <button id="comment-sort-highest-rated">Highest Rated</button>
           </div>
           <button data-modal-close-button class="exit-button">&times;</button>
         </div>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -62,6 +62,7 @@
           <div class="button-group" id="comment-sorting" value="">
             <button id="comment-sort-recent">Recently Posted</button>
             <button id="comment-sort-highest-rated">Highest Rated</button>
+            <button id="comment-sort-relevant">Relevant</button>
           </div>
           <button data-modal-close-button class="exit-button">&times;</button>
         </div>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -112,8 +112,7 @@
                   <textarea id="comment" name="comment" placeholder="Please be as specific as possible..." style="height:200px"></textarea>
                 </div>
               </div>
-              <div class="review-row">
-                <button id="submit-new-review">Submit</button>
+              <div id="submit-button" class="review-row">
               </div>
           </div>
         </div>


### PR DESCRIPTION
This is a bit of a grab-bag of features since I kept stumbling across things I had broken throughout. 
New features include:
-Fixed voting servlet: Previously we were resetting the positive/negative count for voting to zero in the Comment() constructor, turns out this just needed resetting.
-Fixed double-submitting on new reviews: apparently if you call .addEventListener on the same element more than once it just adds multiple listeners, so when we clicked "Submit" on the new review form it would duplicate reviews. This was also a striaght-forward fix once I actually found the bug.
-Fixed sorting review buttons: we were previously using String1 == String2 in our if-else statement when sorting reviews (instead of string1.equals(string2)), this, like the other two, was a really easy fix but so, so hard to track down.
-Changed existing 'sort by relevant button' to 'sort by highest rating' and then added a third 'sort by relevant' button that sorts reviews by a combination of their recency and the score (out of 5) that that review assigns to a particular location. This way, more recent reviews take priority over older ones and higher-rated reviews take priority over lower-rated ones.